### PR TITLE
Bug/curly brace evaluation using cross-spawn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1205,6 +1205,15 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/cross-spawn": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.2.tgz",
+      "integrity": "sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@oclif/dev-cli": "^1",
     "@oclif/test": "^1",
     "@types/chai": "^4.2.12",
+    "@types/cross-spawn": "^6.0.2",
     "@types/inquirer": "^7.3.1",
     "@types/lodash.merge": "^4.6.6",
     "@types/mocha": "^8.0.3",

--- a/src/git-base.ts
+++ b/src/git-base.ts
@@ -61,9 +61,10 @@ export abstract class GitBaseCommand extends Command {
 
   async getCurrentBranchName(options?: SpawnOptions) {
     let gitCurrentBranchName = await this._spawn('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], options)
-    if (gitCurrentBranchName.stdout.trim() === '@u') {   // catch and counteract bash curly brace evaluation
-      gitCurrentBranchName = await this._spawn('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@\\{u\\}'], options)
-    }
+    //if (gitCurrentBranchName.stdout.trim() === '@u') {   // catch and counteract bash curly brace evaluation
+    //  gitCurrentBranchName = await this._spawn('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@\\{u\\}'], options)
+    //}
+    console.dir(gitCurrentBranchName)
     this.log('expectedCurrentBranchName', gitCurrentBranchName.stdout.trim())
     return gitCurrentBranchName.stdout.trim()
   }

--- a/src/util/child-process.ts
+++ b/src/util/child-process.ts
@@ -1,4 +1,5 @@
-import {spawn, SpawnOptions, SpawnSyncReturns, ChildProcess} from 'child_process'
+import {SpawnOptions, SpawnSyncReturns, ChildProcess} from 'child_process'
+import {spawn} from 'cross-spawn'
 import winston from 'winston'
 
 export async function _spawn(logger: winston.Logger, command: string, argsv: readonly string[], options: SpawnOptions): Promise<SpawnSyncReturns<string>> {


### PR DESCRIPTION
Unfortunately, this does not succeed; suffers the same cygwin-resolves-curly-braces error as when using the previous spawn, trying to look up a branch literally called @u .