### PR TITLE
Close nrdk/issues/41 by using a getter for jira and bitbucket clients.

### DIFF
--- a/src/api/service/axios-bitbucket-client.ts
+++ b/src/api/service/axios-bitbucket-client.ts
@@ -21,7 +21,6 @@ export interface CreatePullRequestOptions {
 }
 
 export class AxiosBitBucketClient extends AxiosClient {
-
   static createPullRequestUrl(repo: RepositoryReference, pullRequestNumber: string): string {
     return `https://apps.nrs.gov.bc.ca/int/stash/projects/${repo.project.key}/repos/${repo.slug}/pull-requests/${pullRequestNumber}/overview`
   }

--- a/src/api/service/axios-bitbucket-client.ts
+++ b/src/api/service/axios-bitbucket-client.ts
@@ -1,4 +1,4 @@
-import {AxiosInstance} from 'axios'
+import {AxiosClient} from './axios-client'
 
 export const FIELDS = Object.freeze({
   ISSUE_TYPE: 'issuetype',
@@ -20,8 +20,7 @@ export interface CreatePullRequestOptions {
   toRef: {id: string; repository: RepositoryReference};
 }
 
-export class AxiosBitBucketClient {
-  readonly client: AxiosInstance
+export class AxiosBitBucketClient extends AxiosClient {
 
   static createPullRequestUrl(repo: RepositoryReference, pullRequestNumber: string): string {
     return `https://apps.nrs.gov.bc.ca/int/stash/projects/${repo.project.key}/repos/${repo.slug}/pull-requests/${pullRequestNumber}/overview`
@@ -39,8 +38,8 @@ export class AxiosBitBucketClient {
     return {url: m[0] as string, slug: m.groups?.repository as string, project: {key: m.groups?.project as string}}
   }
 
-  constructor(client: AxiosInstance) {
-    this.client = client
+  constructor(idirAuthorizationHeader: string) {
+    super(process.env.BITBUCKET_URL || 'https://bwa.nrs.gov.bc.ca/int/stash', idirAuthorizationHeader)
   }
 
   public createBranch(projectKey: string, repositorySlug: string, name: string, startPoint: string) {

--- a/src/api/service/axios-client.ts
+++ b/src/api/service/axios-client.ts
@@ -10,11 +10,11 @@ export class AxiosClient {
 
   constructor(baseURL: string, idirAuthorizationHeader: string) {
     this.client = axios.create({
-        baseURL: baseURL,
-        timeout: 10000,
-        headers: {
-          Authorization: idirAuthorizationHeader
-        },
-      })
+      baseURL: baseURL,
+      timeout: 10000,
+      headers: {
+        Authorization: idirAuthorizationHeader,
+      },
+    })
   }
 }

--- a/src/api/service/axios-client.ts
+++ b/src/api/service/axios-client.ts
@@ -1,0 +1,20 @@
+import {AxiosInstance} from 'axios'
+import axios from 'axios'
+
+export const FIELDS = Object.freeze({
+  ISSUE_TYPE: 'issuetype',
+})
+
+export class AxiosClient {
+  client: AxiosInstance
+
+  constructor(baseURL: string, idirAuthorizationHeader: string) {
+    this.client = axios.create({
+        baseURL: baseURL,
+        timeout: 10000,
+        headers: {
+          Authorization: idirAuthorizationHeader
+        },
+      })
+  }
+}

--- a/src/api/service/axios-factory.ts
+++ b/src/api/service/axios-factory.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import {SecretManager, SVC_IDIR_SPEC} from './secret-manager'
 import {AxiosJiraClient} from './axios-jira-client'
 import {AxiosBitBucketClient} from './axios-bitbucket-client'
@@ -16,22 +15,12 @@ export class AxiosFactory {
   }
 
   static async jira(): Promise<AxiosJiraClient> {
-    return new AxiosJiraClient(axios.create({
-      baseURL: process.env.JIRA_URL || 'https://bwa.nrs.gov.bc.ca/int/jira',
-      timeout: 10000,
-      headers: {
-        Authorization: await AxiosFactory.createIdirAuthorizationHeader(),
-      },
-    }))
+    const idirAuthorizationHeader = await AxiosFactory.createIdirAuthorizationHeader()
+    return new AxiosJiraClient(idirAuthorizationHeader)
   }
 
   static async bitBucket(): Promise<AxiosBitBucketClient> {
-    return new AxiosBitBucketClient(axios.create({
-      baseURL: process.env.BITBUCKET_URL || 'https://bwa.nrs.gov.bc.ca/int/stash',
-      timeout: 10000,
-      headers: {
-        Authorization: await AxiosFactory.createIdirAuthorizationHeader(),
-      },
-    }))
+    const idirAuthorizationHeader = await AxiosFactory.createIdirAuthorizationHeader()
+    return new AxiosBitBucketClient(idirAuthorizationHeader)
   }
 }

--- a/src/api/service/axios-jira-client.ts
+++ b/src/api/service/axios-jira-client.ts
@@ -1,5 +1,5 @@
 /* eslint-disable valid-jsdoc */
-import {AxiosInstance} from 'axios'
+import {AxiosClient} from './axios-client'
 import {AxiosBitBucketClient} from './axios-bitbucket-client'
 import {GeneralError} from '../../error'
 import {IssueReference} from '../model/jira'
@@ -11,16 +11,16 @@ export type Issue = {key: string; id: string; fields: any}
 export const FIELDS = Object.freeze({
   ISSUE_TYPE: 'issuetype',
 })
-export class AxiosJiraClient {
+export class AxiosJiraClient extends AxiosClient {
   logger = LoggerFactory.createLogger(__filename.slice(__dirname.length + 1))
 
   // eslint-disable-next-line no-useless-escape
   private static JIRA_ISSUE_KEY_REGEX = /(?<issueKey>\w+-\d+)/m;
 
-  readonly client: AxiosInstance
+  constructor(idirAuthorizationHeader: string) {
+    super(
+      process.env.JIRA_URL || 'https://bwa.nrs.gov.bc.ca/int/jira', idirAuthorizationHeader)
 
-  constructor(client: AxiosInstance) {
-    this.client = client
     this.client.interceptors.response.use(response => {
       this.logger.debug(`< ${response.request.method} - ${response.request.path} - ${response.status}`)
       return response

--- a/src/api/service/secret-manager.ts
+++ b/src/api/service/secret-manager.ts
@@ -1,7 +1,5 @@
-
 import * as fs from 'fs'
 import {homedir} from 'os'
-import * as util from 'util'
 import * as inquirer from 'inquirer'
 import {LoggerFactory} from '../../util/logger'
 import {spawn} from 'child_process'

--- a/src/api/service/secret-manager.ts
+++ b/src/api/service/secret-manager.ts
@@ -97,12 +97,12 @@ export class SecretManager {
   static async getInstance(): Promise<SecretManager> {
     if (!SecretManager.instance) {
       SecretManager.instance = new SecretManager()
-      SecretManager.instance.load()
+      await SecretManager.instance.load()
     }
     return SecretManager.instance
   }
 
-  private load() {
+  private async load() {
     // resolve ~/ to current user home directory
     const location = this.location.replace(/^~(?=$|\/|\\)/, homedir())
     if (fs.existsSync(location)) {

--- a/src/api/service/secret-manager.ts
+++ b/src/api/service/secret-manager.ts
@@ -97,12 +97,12 @@ export class SecretManager {
   static async getInstance(): Promise<SecretManager> {
     if (!SecretManager.instance) {
       SecretManager.instance = new SecretManager()
-      await SecretManager.instance.load()
+      SecretManager.instance.load()
     }
     return SecretManager.instance
   }
 
-  private async load() {
+  private load() {
     // resolve ~/ to current user home directory
     const location = this.location.replace(/^~(?=$|\/|\\)/, homedir())
     if (fs.existsSync(location)) {

--- a/src/api/service/secret-manager.ts
+++ b/src/api/service/secret-manager.ts
@@ -108,8 +108,7 @@ export class SecretManager {
     // resolve ~/ to current user home directory
     const location = this.location.replace(/^~(?=$|\/|\\)/, homedir())
     if (fs.existsSync(location)) {
-      const readFile = util.promisify(fs.readFile)
-      const content = await readFile(location, {encoding: 'utf8'})
+      const content = fs.readFileSync(location, {encoding: 'utf8'})
       Object.assign(this.entries, JSON.parse(content))
     }
   }

--- a/src/commands/backlog/checkin.ts
+++ b/src/commands/backlog/checkin.ts
@@ -27,7 +27,6 @@ export default class BacklogCheckin extends GitBaseCommand {
 
   async getJiraIssue(): Promise<DetailedIssue> {
     this.log('Fetching Jira issue associated with current Git branch')
-    const jira = this.jira as AxiosJiraClient
 
     let gitCurrentTrackingBranchName = await this._spawn('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'])
     if (gitCurrentTrackingBranchName.stdout.trim() === '@u') {   // catch and counteract bash curly brace evaluation
@@ -37,7 +36,7 @@ export default class BacklogCheckin extends GitBaseCommand {
     this.log('expectedCurrentTrackingBranchName', expectedCurrentTrackingBranchName)
 
     const issueKey = await AxiosJiraClient.parseJiraIssueKeyFromUri(expectedCurrentTrackingBranchName)
-    const issue = await jira.getIssue(issueKey, {fields: 'issuetype,components,project'})
+    const issue = await this.jira().getIssue(issueKey, {fields: 'issuetype,components,project'})
 
     const gitPush = await this._spawn('git', ['push', 'origin'])
     if (gitPush.status !== 0) {
@@ -46,7 +45,7 @@ export default class BacklogCheckin extends GitBaseCommand {
 
     const baseBranchName = expectedCurrentTrackingBranchName.split('/').slice(1)
     .join('/')
-    const devDetails = (await jira.getBranches(issue.id))
+    const devDetails = (await this.jira().getBranches(issue.id))
     // console.dir(devDetails.branches)
     const branch = devDetails.branches.find((item: { name: string }) => item.name === baseBranchName)
     if (!branch) {
@@ -63,8 +62,6 @@ export default class BacklogCheckin extends GitBaseCommand {
   }
 
   async createPullRequest(jiraIssue: DetailedIssue) {
-    const jira = this.jira as AxiosJiraClient
-    const bitBucket = this.bitBucket as AxiosBitBucketClient
 
     this.log(`Creating pull request for branch ${jiraIssue.branch.name} ....`)
 
@@ -72,16 +69,16 @@ export default class BacklogCheckin extends GitBaseCommand {
     if (jiraIssue.fields.issuetype.name === 'RFC') {
       rfcIssue = jiraIssue
     } else {
-      rfcIssue = await jira.getRfcByIssue(jiraIssue.key) as DetailedIssue
+      rfcIssue = await this.jira().getRfcByIssue(jiraIssue.key) as DetailedIssue
     }
 
-    const rfcDevDetails = (await jira.getBranches(rfcIssue.id))
+    const rfcDevDetails = (await this.jira().getBranches(rfcIssue.id))
     if (rfcDevDetails.branches.length === 0) {
       return this.error(`Missing release branch 'release/${rfcIssue.key}'`)
     }
     const releaseBranch = rfcDevDetails.branches[0]
     const repository = AxiosBitBucketClient.parseUrl(releaseBranch.url)
-    jiraIssue.pullRequest = await bitBucket.createPullRequest(
+    jiraIssue.pullRequest = await this.bitBucket().createPullRequest(
       {
         title: jiraIssue.key,
         fromRef: {id: `refs/heads/${jiraIssue.branch.name}`, repository},

--- a/src/commands/backlog/checkin.ts
+++ b/src/commands/backlog/checkin.ts
@@ -62,7 +62,6 @@ export default class BacklogCheckin extends GitBaseCommand {
   }
 
   async createPullRequest(jiraIssue: DetailedIssue) {
-
     this.log(`Creating pull request for branch ${jiraIssue.branch.name} ....`)
 
     let rfcIssue: DetailedIssue

--- a/src/commands/backlog/checkout.ts
+++ b/src/commands/backlog/checkout.ts
@@ -42,8 +42,8 @@ export default class GitCheckout extends GitBaseCommand {
   }
 
   async getIssue(issueKey: string): Promise<Issue> {
-    if (!this.jira) return this.error('Jira client has not been initialized')
-    return this.action(`Fetching Jira Issue ${issueKey}`, this.jira.getIssue(issueKey, {fields: 'issuetype,components'}))
+    if (!this.jira()) return this.error('Jira client has not been initialized')
+    return this.action(`Fetching Jira Issue ${issueKey}`, this.jira().getIssue(issueKey, {fields: 'issuetype,components'}))
   }
 
   async gitCloneRepository(branchInfo: BranchReference) {
@@ -101,14 +101,14 @@ export default class GitCheckout extends GitBaseCommand {
    * if the issue branch doesn't exist, one will be created.
    */
   async getIssueBranch(issue: Issue, repository: RepositoryReference, username?: string) {
-    if (!this.jira) return this.error('Jira client has not been initialized')
+    if (!this.jira()) return this.error('Jira client has not been initialized')
     // RFC issues
     if (issue.fields.issuetype.name === 'RFC') {
       return this.createReleaseBranch(issue, repository)
     }
     // non-RFC issues
     this.log(`Finding RFC for issue ${issue.key}/${issue.id}`)
-    const rfc = await this.jira.getRfcByIssue(issue.key)
+    const rfc = await this.jira().getRfcByIssue(issue.key)
     this.log(`Found RFC ${rfc.key}/${rfc.id}`)
     const releaseBranch = await this.createReleaseBranch(rfc, repository)
     let branchName = `feature/${issue.key}`
@@ -119,13 +119,13 @@ export default class GitCheckout extends GitBaseCommand {
   }
 
   async getRepository(issue: Issue, flags: any):  Promise<RepositoryReference> {
-    if (!this.jira) return this.error('Jira client has not been initialized')
+    if (!this.jira()) return this.error('Jira client has not been initialized')
     if (!flags.repository || !flags.project) {
       if (issue.fields.components.length !== 1) {
         return this.error(`Expected at least 1 component set for issue '${issue.key}', but found '${issue.fields.components.length}'`)
       }
       const component = issue.fields.components[0]
-      const repositoryReference = await this.jira.getComponentRepositoryInfo(component)
+      const repositoryReference = await this.jira().getComponentRepositoryInfo(component)
       flags.repository = repositoryReference.slug
       flags.project = repositoryReference.project.key
     }

--- a/src/commands/backlog/resolve.ts
+++ b/src/commands/backlog/resolve.ts
@@ -18,11 +18,9 @@ export default class BacklogResolve extends GitBaseCommand {
 
   async run() {
     const {args, flags} = this.parse(BacklogResolve)
-    const jira = this.jira as AxiosJiraClient
-    const bitBucket = this.bitBucket as AxiosBitBucketClient
     const issueKey = args.issue
     if (!flags.issueId ||  !flags.issueType) {
-      const issue = await jira.getIssue(issueKey, {fields: 'issuetype'})
+      const issue = await this.jira().getIssue(issueKey, {fields: 'issuetype'})
       flags.issueId = issue.id
       flags.issueType = issue.fields.issuetype.name
     }
@@ -33,7 +31,7 @@ export default class BacklogResolve extends GitBaseCommand {
       }
     }
     const issueId = flags.issueId as string
-    const devDetails = (await jira.getBranches(issueId))
+    const devDetails = (await this.jira().getBranches(issueId))
     const branches = devDetails.branches.filter((item: { name: string }) => item.name === flags.branch)
     if (branches.length !== 1) {
       return this.error(`Missing remote branch ${flags.branch}`)
@@ -53,10 +51,10 @@ export default class BacklogResolve extends GitBaseCommand {
       const pullRequestNumber = parseInt((pullRequest.id as string).substr(1), 10) // remove '#' from the beginning of the id
       this.log(`Merging Pull-Request ${pullRequest.id} ...`)
       const repoInfo = AxiosBitBucketClient.parseUrl(pullRequest.url)
-      await bitBucket.mergePullRequest(repoInfo.project.key, repoInfo.slug, pullRequestNumber)
+      await this.bitBucket().mergePullRequest(repoInfo.project.key, repoInfo.slug, pullRequestNumber)
     }
     const sourceBranchRepoInfo = AxiosBitBucketClient.parseUrl(fromBranch.url)
     this.log(`Deleting source branch ${fromBranch.name} ...`)
-    await bitBucket.deleteBranch(sourceBranchRepoInfo.project.key, sourceBranchRepoInfo.slug, fromBranch.name)
+    await this.bitBucket().deleteBranch(sourceBranchRepoInfo.project.key, sourceBranchRepoInfo.slug, fromBranch.name)
   }
 }

--- a/src/commands/backlog/resolve.ts
+++ b/src/commands/backlog/resolve.ts
@@ -1,6 +1,5 @@
 import {GitBaseCommand} from '../../git-base'
 import {flags} from '@oclif/command'
-import {AxiosJiraClient} from '../../api/service/axios-jira-client'
 import {AxiosBitBucketClient} from '../../api/service/axios-bitbucket-client'
 
 export default class BacklogResolve extends GitBaseCommand {


### PR DESCRIPTION
Once more with feeling!

Creates an AxiosClient class that AxiosJiraClient and AxiosBitBucketClient inherit from.
Moves the Axios constructor into the AxiosJiraClient / AxiosBitBucketClient since the factory shouldn't need to know/store the URL.
Replaces `const jira = this.jira as AxiosJiraClient` with a this.jira() helper. Not touching init() for now.
Removes promisify in secret-manager.ts with ReadFileSync, since awaiting a promise isn't better than just doing the work.
