### PR TITLE
Dynamic imports and require cleanups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1169,6 +1169,15 @@
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
+    "@types/unzipper": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.3.tgz",
+      "integrity": "sha512-01mQdTLp3/KuBVDhP82FNBf+enzVOjJ9dGsCWa5z8fcYAFVgA9bqIQ2NmsgNFzN/DhD0PUQj4n5p7k6I9mq80g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.13",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
@@ -2052,6 +2061,7 @@
       "requires": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -4448,6 +4458,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "dev": true,
+      "optional": true
+    },
     "fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -5603,6 +5620,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -5622,6 +5640,13 @@
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
           }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
         },
         "normalize-path": {
           "version": "3.0.0",
@@ -7004,6 +7029,7 @@
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
+            "fsevents": "~2.3.1",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
@@ -7037,6 +7063,13 @@
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
         },
         "is-binary-path": {
           "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/request": "^2.48.5",
     "@types/rsync": "^0.4.30",
     "@types/tar": "^4.0.3",
+    "@types/unzipper": "^0.10.3",
     "chai": "^4",
     "cpx": "^1.5.0",
     "cross-env": "^7.0.3",

--- a/src/archetypes/java-web-app/build.ts
+++ b/src/archetypes/java-web-app/build.ts
@@ -1,5 +1,5 @@
 import {BasicBuilder} from '../../util/basic-builder'
-const path = require('path')
+import * as path from 'path'
 
 const MyBuilder = class extends BasicBuilder {
   // eslint-disable-next-line no-useless-constructor

--- a/src/archetypes/java-web-app/deploy.ts
+++ b/src/archetypes/java-web-app/deploy.ts
@@ -1,5 +1,5 @@
 import {BasicJavaApplicationDeployer} from '../../util/basic-java-application-deployer'
-const path = require('path')
+import * as path from 'path'
 
 const MyDeployer = class extends BasicJavaApplicationDeployer {
   // eslint-disable-next-line no-useless-constructor

--- a/src/tools/maven.ts
+++ b/src/tools/maven.ts
@@ -41,7 +41,7 @@ export class Maven extends Tool {
       const entry = await (await SecretManager.getInstance()).getEntry(SVC_IDIR_SPEC)
       const idirUsername = (await entry.getProperty(SVC_IDIR_SPEC.fields.UPN.name)).getPlainText()
       const idirPassword = (await entry.getProperty(SVC_IDIR_SPEC.fields.PASSWORD.name))
-      const crypto = require('crypto')
+      const crypto = await import('crypto')
       const masterPassword = crypto.randomBytes(16).toString('hex')
       const userConfDir = path.join(mavenHome, 'usr')
       const userSecuritySettingsXmlFile = path.join(userConfDir, 'security-settings.xml')

--- a/src/tools/terraform.ts
+++ b/src/tools/terraform.ts
@@ -35,7 +35,7 @@ export class Terraform extends Tool {
     await MavenHelper.downloadFromUrl(new URL(url), zip)
 
     // Extract
-    const extract = require('unzipper').Extract
+    const extract = (await import('unzipper')).Extract
     return new Promise((resolve, reject) => {
       fs.createReadStream(zip)
       .pipe(extract({path: homeDir}))

--- a/src/tools/terraform/settings.ts
+++ b/src/tools/terraform/settings.ts
@@ -1,4 +1,5 @@
 import {GeneralError} from '../../error'
+import * as os from 'os'
 
 // Version and url vars
 export const version = '0.15.3'
@@ -10,7 +11,7 @@ const zipUrls: Record<string, string> = {
 }
 
 // Select url by os (optional platform override)
-function getUrlByOS(platform = require('os').platform()): string {
+function getUrlByOS(platform = os.platform()): string {
   for (const os in zipUrls) {
     if (os.match(platform)) return zipUrls[os]
   }

--- a/src/util/liquibase.ts
+++ b/src/util/liquibase.ts
@@ -24,7 +24,7 @@ function httpGet(url: URL, callback: (res: http.IncomingMessage) => void): http.
 }
 
 function toJavaClassPath(items: string[]): string {
-  if (require('os').platform() === 'win32') {
+  if (os.platform() === 'win32') {
     return items.join(';')
   }
   return items.join(':')


### PR DESCRIPTION
TypeScript shouldn't use require and could be prevented from doing so with a future update.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html

NOTE: skipped all .js, tests and anything requiring @bcgov/nr-pipeline-ext (to be removed)